### PR TITLE
Fix error on initialization for invalid url

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -200,7 +200,7 @@ export class KonnectedHomebridgePlatform implements DynamicPlatformPlugin {
               if (Object.keys(panelResponseObject.settings).length === 0) {
                 this.provisionPanel(panelUUID, panelResponseObject, listenerObject);
               } else {
-                const panelBroadcastEndpoint = new URL(panelResponseObject.settings.endpoint);
+                const panelBroadcastEndpoint = new URL(`https://${panelResponseObject.settings.endpoint}`);
                 // if the IP address or port are not the same, reprovision endpoint component
                 if (
                   panelBroadcastEndpoint.host !== this.listenerIP ||


### PR DESCRIPTION
On startup the following error would be written to the logs:

error: TypeError [ERR_INVALID_URL]: Invalid URL: xxxxx.iot.us-east-1.amazonaws.com
    at onParseError (internal/url.js:257:9)
    at new URL (internal/url.js:333:5)
    at /usr/local/lib/node_modules/homebridge-konnected/src/platform.ts:203:48
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

The issue is the `settings.endpoint` is something similar to `xxx.iot.us-east-1.amazonaws.com`. When calling `new URL()` the url must have a protocol attached to it.